### PR TITLE
Create shared npm module with .rc files for lint tools.

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,56 @@
+// You can copy this file locally and delete the last “false” rules.
+// This way, we’ll have less issues later while not having to deal with legacy code as a whole.
+
+// See https://github.com/CSSLint/csslint/wiki/Rules-by-ID
+//
+// `1` is for warnings.
+// `2` is for errors.
+// source: https://gist.github.com/nzakas/1781185#file-csslint-api-js-L4
+{
+    "display-property-grouping": true,
+    "duplicate-properties": true,
+    "empty-rules": 2,
+    "known-properties": 2,
+
+    "adjoining-classes": false,
+    "box-sizing": false,
+    "compatible-vendor-prefixes": true,
+    "gradients": true,
+    "text-indent": true,
+    "vendor-prefix": 2,
+    "fallback-colors": true,
+    "star-property-hack": true,
+    "underscore-property-hack": true,
+    "bulletproof-font-face": true,
+
+    "font-faces": true,
+    "import": 2,
+    "regex-selectors": true,
+    "universal-selector": true,
+    "unqualified-attributes": true,
+    "zero-units": 2,
+    "overqualified-elements": true,
+    "shorthand": true,
+    "duplicate-background-images": true,
+
+    "floats": true,
+    "font-sizes": true,
+    "ids": true,
+    "important": false,
+
+    "outline-none": true,
+
+    "qualified-headings": true,
+    "unique-headings": true,
+
+    "non-link-hover": false,
+
+    // These options are more sensitive when dealing with legacy code…
+    "box-model": true,
+    "font-sizes": true,
+    "ids": true,
+    "overqualified-elements": true,
+    "qualified-headings": true,
+    "unique-headings": true,
+    "universal-selector": true
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,md}]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,180 @@
+{
+    // Allow to parse all errors in a file.
+    "maxErrors": "Infinity",
+
+    // While idiomatic js guide gets released…
+    // https://github.com/jscs-dev/node-jscs/blob/master/presets/idiomatic.json
+    // -------------------------------------------------------------------------
+    "preset": "jquery",
+
+    "requireSpacesInsideParentheses": {
+        "all": true,
+        "ignoreParenthesizedExpression": true,
+        "except": [
+            "{", "}",
+            "[", "]",
+            "function",
+            "\""
+        ]
+    },
+
+    "disallowSpacesInCallExpression": true,
+
+    "requireSpaceAfterLineComment": {
+        "allExcept": [
+            "#",
+            "="
+        ]
+    },
+
+    "disallowMultipleLineBreaks": null,
+
+    "requireCapitalizedComments": null,
+
+    // The following are style–guides for Juwai.
+    // -------------------------------------------------------------------------
+
+    // Indentation should be 4 spaces.
+    "validateIndentation": 4,
+
+    // All quote marks should be '.
+    "validateQuoteMarks": "'",
+
+    // No line should be longer than 120 characters.
+    "maximumLineLength": {
+        "value": 120,
+        "tabSize": 4,
+        "allExcept": [
+            "urlComments",
+            "regex"
+        ]
+    },
+
+    // Require newline before line comments.
+    "requirePaddingNewLinesBeforeLineComments": {
+        "allExcept": "firstAfterCurly"
+    },
+
+    // Require space before keywords. This list is consistent with the jQuery
+    // preset for requireSpaceAfterKeywords.
+    "requireSpaceBeforeKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "return",
+        "try",
+        "catch"
+    ],
+
+    // Require space after object keys.
+    "requireSpaceBeforeObjectValues": true,
+
+    // Enable validation of separators between function parameters.
+    "validateParameterSeparator": ", ",
+
+    // Require space before {} in function expressions.
+    "requireSpacesInFunction": {
+        "beforeOpeningCurlyBrace": true
+    },
+
+    // Disallow space before () in function expressions.
+    "disallowSpacesInFunction": {
+        "beforeOpeningRoundBrace": true
+    },
+
+    // Require an extra blank newline after var declarations.
+    "requirePaddingNewLineAfterVariableDeclaration": true,
+
+    // Require a blank line after `'use strict';` statements.
+    "requirePaddingNewLinesAfterUseStrict": true,
+
+    // Require newline after blocks.
+    "requirePaddingNewLinesAfterBlocks": {
+        "allExcept": [
+            "inCallExpressions",
+            "inNewExpressions",
+            "inArrayExpressions",
+            "inProperties"
+        ]
+    },
+
+    // Require an empty line above the specified keywords.
+    // @see https://docs.webplatform.org/wiki/javascript/reserved_words
+    "requirePaddingNewlinesBeforeKeywords": [
+        "case",
+        "continue",
+        "debugger",
+        "default",
+        "delete",
+        "do",
+        "for",
+        "if",
+        "new",
+        "return",
+        "switch",
+        "throw",
+        "try",
+        "void",
+        "while",
+        "with",
+        "yield",
+        "let"
+    ],
+
+    // Require placing object keys on new line.
+    "requireObjectKeysOnNewLine": true,
+
+    // Require a $ before variable names that are jquery assignments.
+    "requireDollarBeforejQueryAssignment": "ignoreProperties",
+
+    // Require var declaration to be on the top of an enclosing scope.
+    "requireVarDeclFirst": true,
+
+    // Disallow multiple var declaration (except for-loop).
+    "disallowMultipleVarDecl": {
+        "allExcept" : [
+            "undefined"
+        ]
+    },
+
+    // Require space after opening and before closing grouping parentheses.
+    "requireSpacesInsideParenthesizedExpression": {
+        "allExcept": [
+            "function",
+            "{", "}"
+        ]
+    },
+
+    // Require identifiers to be camelCased or UPPERCASE_WITH_UNDERSCORES.
+    // This won’t be sustainable for now.
+    "requireCamelCaseOrUpperCaseIdentifiers": false,
+
+    // Validate JSDoc rules.
+    "jsDoc": {
+        "checkAnnotations": {
+            "preset": "jsdoc3"
+        },
+        "checkParamNames": true,
+        "requireParamTypes": true,
+        "checkRedundantParams": true,
+        "checkReturnTypes": true,
+        "checkRedundantReturns": true,
+        "requireReturnTypes": true,
+        "checkTypes": true,
+        "checkRedundantAccess": true,
+        // This should be enabled on next PR, after upgrading JSCS to new version.
+        // "enforceExistence": {
+        //     "allExcept": [
+        //         "expressions",
+        //         "exports",
+        //         "paramless-procedures"
+        //     ]
+        // },
+        "requireHyphenBeforeDescription": true,
+        "requireNewlineAfterDescription": true,
+        "requireDescriptionCompleteSentence": true
+    }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+    // Predefined globals.
+    // Do not add more unless they can be found in every project.
+    "predef": [
+        "window",
+        "document",
+        // jQuery
+        "$",
+        "jQuery",
+        // Juwai
+        "JW"
+    ],
+    // Use strict equality: ===.
+    "eqnull": false,
+    // Use strict mode.
+    "strict": true,
+    // Error for global variables.
+    // You can specify the globals with this code in the scope:
+    // /* globals myGlobal1, myGlobal2, … */
+    "undef":  true,
+    // Error if some variables are not used.
+    "unused": false
+}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ These are files used across our projects to lint our files.
 
 ## Install
 
-1. Make sure node is installed in your environment.
-1. `cd` to your repository.
-1. Run `npm install juwai/juwai-lint-cfg --save-dev` to pull the package from git.
+1. Make sure [node.js](https://nodejs.org/en/download/) is installed in your environment.
+1. `cd` to the root of your project’s repository.
+1. Run `$ npm install juwai/juwai-lint-cfg --save-dev` to install the module from
+    git and save it to the configuration of the project.
 1. Answer the question during installation.
 1. Files should be now copied to the root of your repository, ready to lint your code!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Lint configuration files
+
+These are files used across our projects to lint our files.
+
+## Install
+
+1. Make sure node is installed in your environment.
+1. `cd` to your repository.
+1. Run `npm install juwai/juwai-lint-cfg --save-dev` to pull the package from git.
+1. Answer the question during installation.
+1. Files should be now copied to the root of your repository, ready to lint your code!

--- a/README.md
+++ b/README.md
@@ -8,5 +8,4 @@ These are files used across our projects to lint our files.
 1. `cd` to the root of your project’s repository.
 1. Run `$ npm install juwai/juwai-lint-cfg --save-dev` to install the module from
     git and save it to the configuration of the project.
-1. Answer the question during installation.
 1. Files should be now copied to the root of your repository, ready to lint your code!

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/juwai/juwai-lint-cfg/issues"
   },
-  "homepage": "https://github.com/juwai/juwai-lint-cfg#readme"
+  "homepage": "https://github.com/juwai/juwai-lint-cfg#readme",
+  "dependencies": {
+    "bluebird": "^3.0.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "juwai-lint-cfg",
+  "version": "1.0.0",
+  "description": ".rc files used by travis and other linting tools at Juwai",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/juwai/juwai-lint-cfg.git"
+  },
+  "keywords": [
+    "lint",
+    "config"
+  ],
+  "author": "juwai",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/juwai/juwai-lint-cfg/issues"
+  },
+  "homepage": "https://github.com/juwai/juwai-lint-cfg#readme"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": ".rc files used by travis and other linting tools at Juwai",
   "main": "index.js",
+  "scripts": {
+    "install": "node scripts/install.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/juwai/juwai-lint-cfg.git"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -8,7 +8,7 @@
     var process = require( 'process' );
 
     var modulePath = process.cwd();
-    var files     = [
+    var files = [
         '.csslintrc',
         '.editorconfig',
         '.jscsrc',

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -15,40 +15,22 @@
         '.jshintrc'
     ];
 
-    // Open the standard input and ask a question.
-    process.stdin.resume();
+    // Get the path of the repository, from the first occurrence of `/node_modules/`.
+    var rootLength = modulePath.indexOf( '/node_modules/' ) + 1;
+    var repositoryRoot = modulePath.slice( 0, rootLength );
+
     process.stdout.write(
-        'What is the name of the folder where the repository lives?\n'
+        '--------------------------------------------------------------------------------\n' +
+        'I will now copy the files into “' + repositoryRoot + '”…\n'
     );
 
-    // When some answer is provided, try to copy the files.
-    process.stdin.once( 'data', function( dest ) {
-        var destPath, destIndex;
+    // Exit current process only once all files are copied.
+    copyFiles( repositoryRoot ).then(function() {
+        process.stdout.write(
+            'All the .rc files for linters were copied successfully. ------------------------\n\n'
+        );
 
-        // Make sure to have a clean user input.
-        // Check if the string exists in the current path.
-        dest = '/' + dest.toString().trim() + '/';
-        destIndex = modulePath.indexOf( dest );
-
-        if ( destIndex !== -1 ) {
-            destPath = modulePath.slice( 0, destIndex + dest.length );
-            process.stdout.write(
-                'I found ' + destPath + '. I will copy the files now…\n'
-            );
-
-            // Exit current process only once all files are copied.
-            copyFiles( destPath ).then(function() {
-                console.log( 'All the files were copied successfully.' );
-                process.exit();
-            });
-        } else {
-            process.stdout.write(
-                'The folder “' + dest + '” doesn’t seem to exist in this ' +
-                'module’s path (' + modulePath + '), try again?\n'
-            );
-
-            process.exit();
-        }
+        process.exit();
     });
 
     /**
@@ -67,7 +49,7 @@
                 var fileRead       = readFileAsync( file );
 
                 return fileRead.then( function( fileContent ) {
-                    console.log( 'Copying ' + file + ' to ' + dest + file + '…' );
+                    process.stdout.write( 'Copying ' + file + ' to ' + dest + file + '…\n' );
 
                     return writeFileAsync( dest + file, fileContent );
                 });

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,56 @@
+(function() {
+    'use strict';
+
+    var console    = require( 'console' );
+    var fs         = require( 'fs' );
+    var module     = require( 'module' );
+    var process    = require( 'process' );
+
+    var modulePath = process.cwd();
+    var files      = [
+        '.csslintrc',
+        '.editorconfig',
+        '.jscsrc',
+        '.jshintrc'
+    ];
+
+    // Open the standard input and ask a question.
+    process.stdin.resume();
+    process.stdout.write( 'What is the name of the folder where the repository lives?\n' );
+
+    // When some answer is provided, try to copy the files.
+    process.stdin.once( 'data', function( dest ) {
+        var destPath, destIndex;
+
+        // Make sure to have a clean user input.
+        // Check if the string exists in the current path.
+        dest = dest.toString().trim();
+        destIndex = modulePath.indexOf( dest );
+
+        if ( destIndex !== -1 ) {
+            destPath = modulePath.slice( 0, destIndex + dest.length + 1 );
+            copyFiles( destPath );
+        } else {
+            process.stdout.write(
+                'The folder “' + dest + '” doesn’t seem to exist in this ' +
+                'module’s path (' + modulePath + '), try again?\n'
+            );
+        }
+
+        process.exit();
+    });
+
+    /**
+     * Copy files to a specific folder.
+     *
+     * @param  {string} dest - Folder to copy the files to.
+     */
+    function copyFiles( dest ) {
+        files.forEach(function( file, index ) {
+            console.log( 'Copying ' + file + ' to ' + dest + file + '…' );
+
+            // http://stackoverflow.com/questions/11293857/fastest-way-to-copy-file-in-node-js
+            fs.createReadStream( file ).pipe( fs.createWriteStream( dest + file ) );
+        });
+    }
+})();

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,13 +1,14 @@
+/* globals require */
 (function() {
     'use strict';
 
-    var console    = require( 'console' );
-    var fs         = require( 'fs' );
-    var module     = require( 'module' );
-    var process    = require( 'process' );
+    var Promise = require( 'bluebird' );
+    var console = require( 'console' );
+    var fs      = require( 'fs' );
+    var process = require( 'process' );
 
     var modulePath = process.cwd();
-    var files      = [
+    var files     = [
         '.csslintrc',
         '.editorconfig',
         '.jscsrc',
@@ -16,7 +17,9 @@
 
     // Open the standard input and ask a question.
     process.stdin.resume();
-    process.stdout.write( 'What is the name of the folder where the repository lives?\n' );
+    process.stdout.write(
+        'What is the name of the folder where the repository lives?\n'
+    );
 
     // When some answer is provided, try to copy the files.
     process.stdin.once( 'data', function( dest ) {
@@ -24,33 +27,51 @@
 
         // Make sure to have a clean user input.
         // Check if the string exists in the current path.
-        dest = dest.toString().trim();
+        dest = '/' + dest.toString().trim() + '/';
         destIndex = modulePath.indexOf( dest );
 
         if ( destIndex !== -1 ) {
-            destPath = modulePath.slice( 0, destIndex + dest.length + 1 );
-            copyFiles( destPath );
+            destPath = modulePath.slice( 0, destIndex + dest.length );
+            process.stdout.write(
+                'I found ' + destPath + '. I will copy the files now…\n'
+            );
+
+            // Exit current process only once all files are copied.
+            copyFiles( destPath ).then(function() {
+                console.log( 'All the files were copied successfully.' );
+                process.exit();
+            });
         } else {
             process.stdout.write(
                 'The folder “' + dest + '” doesn’t seem to exist in this ' +
                 'module’s path (' + modulePath + '), try again?\n'
             );
-        }
 
-        process.exit();
+            process.exit();
+        }
     });
 
     /**
      * Copy files to a specific folder.
+     * This function uses promises to deal with latency between read and write operations.
+     * Not doing so will lead to the creation of empty files.
      *
+     * @see  http://bluebirdjs.com/docs/api-reference.html
      * @param  {string} dest - Folder to copy the files to.
      */
     function copyFiles( dest ) {
-        files.forEach(function( file, index ) {
-            console.log( 'Copying ' + file + ' to ' + dest + file + '…' );
+        return Promise.all(
+            files.map(function( file, index ) {
+                var readFileAsync  = Promise.promisify( fs.readFile );
+                var writeFileAsync = Promise.promisify( fs.writeFile );
+                var fileRead       = readFileAsync( file );
 
-            // http://stackoverflow.com/questions/11293857/fastest-way-to-copy-file-in-node-js
-            fs.createReadStream( file ).pipe( fs.createWriteStream( dest + file ) );
-        });
+                return fileRead.then( function( fileContent ) {
+                    console.log( 'Copying ' + file + ' to ' + dest + file + '…' );
+
+                    return writeFileAsync( dest + file, fileContent );
+                });
+            })
+        );
     }
 })();


### PR DESCRIPTION
The repository is a npm module.

This PR will allow the following:
1. Have a centralize repository with only .rc files.
1. It will copy or overwrite the .rc files to the folder specified by the user during the installation.
1. Until this PR is merged, you can install it in any folder with `npm install arkhi/juwai-lint-cfg`.

Copying files instead of linking them allows to fine–tune linting per project and visualize diff when updating the files in the future.

.rc files might be updated to match latest linters development in the near future, but I kept the compatibility with juwai-admin for now.
