### PR TITLE
[documentation] Update to better match onboarding needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,22 @@ These files are used by Travis-CI when opening a Pull Request, and you can also 
 
 ### Sublime-Text
 
-You can install the following plugins to have live linting in Sublime–Text:
+You can install the following plugins to have live linting in Sublime–Text.
+Their installation is usually really similar, so please refer to their documentation if something is not working, or ask around with your specific problem.
 
-- SublimeLinter: https://packagecontrol.io/packages/SublimeLinter
-- CSS coding standards and pitfalls:
-    - .stylelintrc: https://packagecontrol.io/packages/SublimeLinter-contrib-stylelint
-    - .csslintrc: https://packagecontrol.io/packages/SublimeLinter-csslint (**deprecated**)
-- General code standards (indentation, etc.):
+1. SublimeLinter: https://packagecontrol.io/packages/SublimeLinter
+2. **Essential for all projects**:
     - .editorconfig: https://packagecontrol.io/packages/EditorConfig
-    - Highlights TODO, FIXME, etc.: https://packagecontrol.io/packages/SublimeLinter-annotations
-- JavaScript:
+
+3. JavaScript:
     - .jscsrc (coding standards): https://packagecontrol.io/packages/SublimeLinter-jscs
     - .jshintrc (common errors): https://packagecontrol.io/packages/SublimeLinter-jshint
+
+4. CSS:
+    - .stylelintrc: https://packagecontrol.io/packages/SublimeLinter-contrib-stylelint
+    - .csslintrc: https://packagecontrol.io/packages/SublimeLinter-csslint (**deprecated**, but still in use in some project)
+
+You can also install tools to assist you with style-guides:
+
+- [SublimeLinter-annotations](https://packagecontrol.io/packages/SublimeLinter-annotations) will highlight all TODO, README, FIXME, etc.
+- [JSCS Formatter](https://packagecontrol.io/packages/JSCS-Formatter) will format your code based on the rules we’re using to lint the code. **This package is huge time saver**.


### PR DESCRIPTION
This follows common pitfalls with people onboarding, and multiple PR with comments about line ending, number of characters per line, etc. I can add a list of comments or PR here for reference if you want.

All these checks can be highlighted by these linters before any commit or PR is done, and save us some comments and time.
- Put editorconfig first.
- Add JSCS formatter.

@juwai/all: Please have a look when you can.
