### PR TITLE
Tiny update

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,11 +2,6 @@
     // Predefined globals.
     // Do not add more unless they can be found in every project.
     "predef": [
-        "window",
-        "document",
-        // jQuery
-        "$",
-        "jQuery",
         // Juwai
         "JW"
     ],
@@ -32,5 +27,14 @@
     "maxdepth": 3,
 
     // Identify possibly unsafe line breaks.
-    "laxbreak": true
+    "laxbreak": true,
+
+    // Standard browser globals e.g. `window`, `document`.
+    "browser": true,
+
+    // Enable globals exposed by jQuery JavaScript library.
+    "jquery": true,
+
+    // Enable globals available when code is running inside of the NodeJS runtime environment.
+    "node": true
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -3,9 +3,7 @@
     'use strict';
 
     var Promise = require( 'bluebird' );
-    var console = require( 'console' );
     var fs      = require( 'fs' );
-    var process = require( 'process' );
 
     var modulePath = process.cwd();
     var files = [


### PR DESCRIPTION
## Summary of changes
1. Added jshint options to deal with browser, jQuery and Node global variables.
2. Removed unnecessary require calls.
## How to Test

You can test it in the listed NodeJS versions:
1. `v0.10.46`
2. `v0.12.15`
3. `v4.4.7`
4. `v5.12.0`
5. `v6.2.2`

Run `$ npm install git://github.com/HouCoder/juwai-lint-cfg.git#tiny-update` without any error.
## Note:

You can have multiple NodeJS versions by using [nvm](https://github.com/creationix/nvm).

/fyi: @arkhi @ben-juwai : Please review.
