### PR TITLE
Update stylelintrc.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,7 +15,7 @@
             "severity": "warning"
         }],
 
-        "number-zero-length-no-unit": true,
+        "length-zero-no-unit": true,
 
         "string-no-newline": true,
         "string-quotes": "double",

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -8,7 +8,7 @@
         "color-named": "never",
         "color-no-invalid-hex": true,
 
-        "font-family-name-quotes": [ "double-where-recommended", {
+        "font-family-name-quotes": [ "always-where-recommended", {
             "severity": "warning"
         }],
         "font-weight-notation": [ "numeric", {


### PR DESCRIPTION
## Summary of changes
- `number-zero-length-no-unit` has been deprecated, and will be removed in '7.0'. Use 'length-zero-no-unit' instead.

You can find more detail in the changelog: http://stylelint.io/CHANGELOG/#700.

/fyi: @arkhi , @monochrome-yeh : Please review.
