### PR TITLE
[IND-71] Install rc file for stylelint.

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -10,7 +10,8 @@
         '.csslintrc',
         '.editorconfig',
         '.jscsrc',
-        '.jshintrc'
+        '.jshintrc',
+        '.stylelintrc'
     ];
 
     // Get the path of the repository, from the first occurrence of `/node_modules/`.


### PR DESCRIPTION
**Story on Jira:** http://jira.juwai.com/browse/IND-71
## Summary of changes
- We’re setting up linters on Redkeep and I just  realized the install script was copying .csslintrc and not .stylelintrc. This PR should fix the issue.
- I kept .csslintrc as it can still be helpful for those who want to have hints stylelint doesn’t provide yet.
## How to Test
1. `cd` to the root of a repository.
2. Remove .stylelintrc, if you have one (`rm .stylelintrc`).
3. Run `npm install juwai/juwai-lint-cfg` to install the rc files.
4. A `.stylelintrc` file should have been copied to the root the repository.
