### PR TITLE
Add property-no-unknown.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -29,6 +29,8 @@
         "value-list-comma-space-before": "never",
 
         "custom-property-no-outside-root": true,
+        
+        "property-no-unknown": true,
 
         "declaration-bang-space-after": "never",
         "declaration-bang-space-before": "always",


### PR DESCRIPTION
## Summary of changes

Useful rule to find typos that would lead to code being ignored, and potentially confusing.

This is a follow-up to https://github.com/juwai/juwai-lint-cfg/pull/13#issuecomment-243688241.
## How to Test
1. Run `npm install` in your juwai-com-v2 repository.
2. With linters installed in your editor, write some declaration with a typo in the property.
3. Linter should highlight the line you wrote.
