### PR TITLE
[Hotfix] add stylelint module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/juwai/juwai-lint-cfg#readme",
   "dependencies": {
-    "bluebird": "^3.0.5"
+    "bluebird": "^3.0.5",
+    "stylelint": "^7.3.1"
   }
 }


### PR DESCRIPTION
## Summary of changes
- Add stylelint module in package.json
## How to Test
- The others repository will use `juwai-lint-cfg`'s stylelint module.
- We have to do as following actions once in your main repository:
  - The other repositories have to remove their package.json's stylelint
  - The other repositories have to change their grunt/gulp/wepack 's module link to here.
    - for example: `require( 'juwai-lint-cfg/node_modules/stylelint' );`
## Note
- We could accord stylelint version with .stylelintrc in this repository now.

/fyi: @HouCoder , @ben-juwai , @jonlys-juwai 
/cc: @arkhi 
