### PR TITLE
[hotfix] Update repositories linters with juwai-lint-cfg packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "juwai-lint-cfg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": ".rc files used by travis and other linting tools at Juwai",
   "main": "index.js",
+  "config": {
+    "only": "prod"
+  },
   "scripts": {
-    "install": "node scripts/install.js"
+    "install": "node scripts/install.js",
+    "postinstall": "node scripts/postinstall.js"
   },
   "repository": {
     "type": "git",
@@ -22,5 +26,11 @@
   "homepage": "https://github.com/juwai/juwai-lint-cfg#readme",
   "dependencies": {
     "bluebird": "^3.0.5"
+  },
+  "devDependencies": {
+    "jscs": "3.0.7",
+    "jshint": "2.9.3",
+    "lintspaces-cli": "0.4.0",
+    "stylelint": "7.3.1"
   }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -19,14 +19,15 @@
     var repositoryRoot = modulePath.slice( 0, rootLength );
 
     process.stdout.write(
-        '--------------------------------------------------------------------------------\n' +
-        'I will now copy the files into “' + repositoryRoot + '”…\n'
+        '--------------------------------------------------------------------------------\n'
+        + 'I will now copy linters config files into “' + repositoryRoot + '”…\n'
     );
 
     // Exit current process only once all files are copied.
     copyFiles( repositoryRoot ).then(function() {
         process.stdout.write(
-            'All the .rc files for linters were copied successfully. ------------------------\n\n'
+            'All the linters config files were copied successfully.'
+            + '\n--------------------------------------------------------------------------------\n\n'
         );
 
         process.exit();
@@ -37,12 +38,13 @@
      * This function uses promises to deal with latency between read and write operations.
      * Not doing so will lead to the creation of empty files.
      *
-     * @see  http://bluebirdjs.com/docs/api-reference.html
-     * @param  {string} dest - Folder to copy the files to.
+     * @see http://bluebirdjs.com/docs/api-reference.html
+     *
+     * @param {string} dest - Folder to copy the files to.
      */
     function copyFiles( dest ) {
         return Promise.all(
-            files.map(function( file, index ) {
+            files.map(function( file ) {
                 var readFileAsync  = Promise.promisify( fs.readFile );
                 var writeFileAsync = Promise.promisify( fs.writeFile );
                 var fileRead       = readFileAsync( file );

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,57 @@
+/* globals require */
+(function() {
+    'use strict';
+
+    const exec   = require( 'child_process' ).exec;
+    const config = require( '../package.json' );
+
+    const devDependencies = config.devDependencies;
+    const modulePath      = process.cwd();
+
+    // Get the path of the main repository and its related npm binaries.
+    // The path is based on the first occurrence of `/node_modules/` in the path.
+    var rootLength     = modulePath.indexOf( '/node_modules/' ) + 1;
+    var repositoryRoot = modulePath.slice( 0, rootLength );
+    var command        = 'npm install --save-dev';
+    var dependency;
+
+    // Build command to execute based on dev dependencies
+    for ( dependency in devDependencies ) {
+        command += ` ${ dependency }@${ devDependencies[ dependency ] }`;
+    }
+
+    process.stdout.write(
+        '--------------------------------------------------------------------------------\n'
+        + 'I will now install linters as dependencies into “' + repositoryRoot + '”…\n'
+    );
+
+    /**
+     * Execute command defined based on package\.json.
+     *
+     * @param {string}   command
+     * @param {object}   options
+     * @param {function} callback
+     */
+    exec(
+        command,
+        { 'cwd': repositoryRoot },
+        function( error, stdout, stderr ) {
+            if ( error ) {
+                console.error(
+                    'An error occured while installing linters:\n'
+                    + error
+                    + '\n--------------------------------------------------------------------------------\n\n'
+                );
+
+                return;
+            }
+
+            process.stdout.write(
+                'Linters were installed successfully with ' + ( stderr
+                    ? 'warnings: \n' + stderr
+                    : 'no warning.'
+                ) + '\n--------------------------------------------------------------------------------\n\n'
+            );
+        }
+    );
+})();


### PR DESCRIPTION
**User Story in Jira**: http://jira.juwai.com/browse/EN-1452 
## Summary of changes

I tried a couple of different ways and this one is the most reliable and less intrusive I could find so far. Please speak up if you know something more clever (I’m convinced there is…).

If juwai-lint-cfg is being installed as a dependency, then all its devDependencies will be installed and saved in the package.json of the oldest ancestor’s repository.

This means we shouldn’t have to update every project every time we want to update juwai-lint-cfg. Updates should spread.

I added [`"only": "prod"`](https://docs.npmjs.com/misc/config#only) to avoid installing the devDependencies twice.
## How to Test
1. In the package.json file from any parent repository using juwai-lint-cfg, change the value of `juwai-lint-cfg` to `git+https://github.com/arkhi/juwai-lint-cfg.git#hotfix-handle-dependencies` to install the version from this PR:
   
   ``` json
   "devDependencies": {
     …
     "juwai-lint-cfg": "git+https://github.com/arkhi/juwai-lint-cfg.git#hotfix-handle-dependencies",
     …
   }
   ```
2. Run `npm install` in the parent repository.
3. The linters are now installed in the parent repository.
4. The versions of the packages in the package.json of the parent repository are updated to the ones in the package.json of this PR.
